### PR TITLE
Fix the compilation issue #3 and add the force evaluation feature #2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ Linux/*.o
 Linux/zasm
 OSX/zasm
 
+#eclipse stuff
+.cproject
+.project
+.settings
+
+

--- a/FreeBSD-ARM/Makefile
+++ b/FreeBSD-ARM/Makefile
@@ -100,7 +100,7 @@ FD.o:
 	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o FD.o ../Libraries/unix/FD.cpp
 
 tempmem.o: 
-	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o tempmem.o ../Libraries/unix/tempmem.cpp
+	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o tempmem.o ../Libraries/cstrings/tempmem.cpp
 
 files.o: 
 	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o files.o ../Libraries/unix/files.cpp

--- a/FreeBSD/Makefile
+++ b/FreeBSD/Makefile
@@ -100,7 +100,7 @@ FD.o:
 	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o FD.o ../Libraries/unix/FD.cpp
 
 tempmem.o: 
-	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o tempmem.o ../Libraries/unix/tempmem.cpp
+	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o tempmem.o ../Libraries/cstrings/tempmem.cpp
 
 files.o: 
 	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o files.o ../Libraries/unix/files.cpp

--- a/Linux/Makefile
+++ b/Linux/Makefile
@@ -73,7 +73,7 @@ FD.o:
 	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o FD.o ../Libraries/unix/FD.cpp
 
 tempmem.o:
-	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o tempmem.o ../Libraries/unix/tempmem.cpp
+	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o tempmem.o ../Libraries/cstrings/tempmem.cpp
 
 files.o:
 	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o files.o ../Libraries/unix/files.cpp

--- a/OSX/Makefile
+++ b/OSX/Makefile
@@ -73,7 +73,7 @@ FD.o:
 	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o FD.o ../Libraries/unix/FD.cpp
 
 tempmem.o:
-	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o tempmem.o ../Libraries/unix/tempmem.cpp
+	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o tempmem.o ../Libraries/cstrings/tempmem.cpp
 
 files.o:
 	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o files.o ../Libraries/unix/files.cpp

--- a/Source/Source.cpp
+++ b/Source/Source.cpp
@@ -183,6 +183,8 @@ cstr SourceLine::nextWord ()
 	case ')':	return ")";
 	case ',':	return ",";
 	case '=':	return "=";
+	case '{':	return "{";
+	case '}':	return "}";
 
 	case '\'':							// 'abcd' ''' or ''
 		if (*p==c) { p++; if (*p!=c) return "''"; p++; return "'''"; }	// special test for '''

--- a/Source/Z80Assembler.cpp
+++ b/Source/Z80Assembler.cpp
@@ -1023,6 +1023,7 @@ w:	cstr w = q.nextWord();			// get next word
 		case '~':	n = ~value(q,pUna); goto op;			// complement
 		case '!':	n = !value(q,pUna); goto op;			// negation
 		case '(':	n =  value(q,pAny); q.expect(')'); goto op;	// brackets
+		case '{':	n =  value(q,pAny); q.expect('}'); goto op;	// force interpretation
 		case '.':
 		case '$':	n = dollar();  goto op;
 		case '<':	q.expect('('); goto lo;		// SDASZ80: low byte of word
@@ -2169,6 +2170,20 @@ void Z80Assembler::asmMacroCall (SourceLine& q, Macro& m) throws
 			j = p + strlen(rpl[a]) - s.text;
 			s.text = catstr(substr(s.text,p), rpl[a], s.p);
 		}
+
+        // Now check for interpretation bracket within the source.
+		// Interpretation brackets are '(' and ')'. If found, that code
+        // will be interpreted and its value will be returned.
+		for (int32 j=0;;j++)			// loop over occurrences of '('
+		{
+			cptr p = strchr(s.text+j,'{');	    // at next '{'
+			if (!p) break;						// no more '{'
+			s.p = p;							// set the parser position
+			Value v = value(s, pAny);			// get the value
+            j = s.p - p;
+            s.text = catstr(substr(s.text,p), usingstr("%i ", v.value), s.p);
+		}
+
 		s.rewind();	// superflux. but makes s.p valid
 	}
 


### PR DESCRIPTION
- It is now possible to compile the project from a "virgin" computer.
- It is now possible to force label arithmetic in macros using '{' and '}' delimiters.