### PR TITLE
Tempmem fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ Linux/*.o
 Linux/zasm
 OSX/zasm
 
+#eclipse files and folders
+.cproject
+.project
+.settings

--- a/FreeBSD-ARM/Makefile
+++ b/FreeBSD-ARM/Makefile
@@ -100,7 +100,7 @@ FD.o:
 	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o FD.o ../Libraries/unix/FD.cpp
 
 tempmem.o: 
-	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o tempmem.o ../Libraries/unix/tempmem.cpp
+	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o tempmem.o ../Libraries/cstrings/tempmem.cpp
 
 files.o: 
 	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o files.o ../Libraries/unix/files.cpp

--- a/FreeBSD/Makefile
+++ b/FreeBSD/Makefile
@@ -100,7 +100,7 @@ FD.o:
 	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o FD.o ../Libraries/unix/FD.cpp
 
 tempmem.o: 
-	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o tempmem.o ../Libraries/unix/tempmem.cpp
+	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o tempmem.o ../Libraries/cstrings/tempmem.cpp
 
 files.o: 
 	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o files.o ../Libraries/unix/files.cpp

--- a/Linux/Makefile
+++ b/Linux/Makefile
@@ -73,7 +73,7 @@ FD.o:
 	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o FD.o ../Libraries/unix/FD.cpp
 
 tempmem.o:
-	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o tempmem.o ../Libraries/unix/tempmem.cpp
+	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o tempmem.o ../Libraries/cstrings/tempmem.cpp
 
 files.o:
 	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o files.o ../Libraries/unix/files.cpp

--- a/OSX/Makefile
+++ b/OSX/Makefile
@@ -73,7 +73,7 @@ FD.o:
 	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o FD.o ../Libraries/unix/FD.cpp
 
 tempmem.o:
-	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o tempmem.o ../Libraries/unix/tempmem.cpp
+	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o tempmem.o ../Libraries/cstrings/tempmem.cpp
 
 files.o:
 	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o files.o ../Libraries/unix/files.cpp


### PR DESCRIPTION
All makefiles were seeking `tempmem.cpp` in `../Libraries/unix` but the file is actually in `../Libraries/cstrings`.