### PR TITLE
Add variant to call to z80_opcode_length

### DIFF
--- a/Source/listfile.cpp
+++ b/Source/listfile.cpp
@@ -174,7 +174,7 @@ static cstr compound_cc_str (uint8* bytes, uint count, uint32& cc, CpuID variant
 
 		cc += z80_clock_cycles(op1,op2,op4,variant);
 
-		uint len = z80_opcode_length(bytes);
+		uint len = z80_opcode_length(bytes,variant);
 		assert(len<=count);
 		bytes += len;
 		count -= len;


### PR DESCRIPTION
This PR updates a call to `z80_opcode_length` to include the CPU variant.

The affected code was the location of a segmentation fault when writing a listing with cycle timing for a Z180 source file that included a `TST n` instruction. The responsible error was elsewhere (see Megatokio/Libraries#3) rather than this code. I added the `variant` argument to the `z80_opcode_length()` call anyway - but I think it won't have any behavioural change.