### PR TITLE
Compile Error (-std=c++11)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ STRIP       = strip
 DEFINES     = -DNDEBUG -DRELEASE
 
 CFLAGS      = -pipe -Os -Wall -W -fPIE $(DEFINES)
-CXXFLAGS    = $(CFLAGS) -Wno-multichar -std=c++11
+CXXFLAGS    = $(CFLAGS) -Wno-multichar -std=c++14
 INCPATH     = -I. -ISource -ILibraries
 LFLAGS      =
 LIBS        = -lpthread -lz


### PR DESCRIPTION
Hello, Kio.
Thanks for this useful software !

Execute make, Compile error occurs.
```
 > make
    :
g++ -c -pipe -Os -Wall -W -fPIE -DNDEBUG -DRELEASE -Wno-multichar -std=c++11 -I. -ISource -ILibraries -o tmp/Error.o Source/Error.cpp
In file included from Source/Source.h:24,
                 from Source/Error.h:22,
                 from Source/Error.cpp:27:
Libraries/Templates/RCPtr.h:72:30: error: 'std::enable_if_t' has not been declared
   72 | #define subclass_only   std::enable_if_t<std::is_base_of<T,T2>::value, int> = 1
```
Modify Makefile as follow,  I can build zasm.
`  
CXXFLAGS    = $(CFLAGS) -Wno-multichar -std=c++14
`